### PR TITLE
Add additional document-related permissions to PermissionSeeder

### DIFF
--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -13,7 +13,16 @@ class PermissionSeeder extends Seeder
     public function run(): void
     {
         $permissions = [
+            'view document histories',
             'view dashboard',
+            'view documents',
+            'create documents',
+            'edit documents',
+            'delete documents',
+            'view document types',
+            'create document types',
+            'edit document types',
+            'delete document types',
             'view users',
             'create users',
             'edit users',


### PR DESCRIPTION
- Introduced new permissions for document management, including 'view documents', 'create documents', 'edit documents', 'delete documents', 'view document types', 'create document types', 'edit document types', and 'delete document types'.
- Enhanced the PermissionSeeder to support comprehensive access control for document-related functionalities.